### PR TITLE
Fixed typo in _fitpack2.py

### DIFF
--- a/scipy/interpolate/_fitpack2.py
+++ b/scipy/interpolate/_fitpack2.py
@@ -122,7 +122,7 @@ class UnivariateSpline:
         * if ext=0 or 'extrapolate', return the extrapolated value.
         * if ext=1 or 'zeros', return 0
         * if ext=2 or 'raise', raise a ValueError
-        * if ext=3 of 'const', return the boundary value.
+        * if ext=3 or 'const', return the boundary value.
 
         Default is 0.
 


### PR DESCRIPTION
Changed "of" to "or" because the typo was bugging me when I was reading the docs
